### PR TITLE
chore: move core deps to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentica/openai-vector-store",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentica/openai-vector-store",
-      "version": "0.0.2",
+      "version": "0.0.4",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.744.0",

--- a/package.json
+++ b/package.json
@@ -23,16 +23,18 @@
   "description": "",
   "devDependencies": {
     "@agentica/core": "^0.11.1",
-    "ts-patch": "^3.3.0",
-    "typescript": "~5.8.2"
-  },
-  "dependencies": {
     "@aws-sdk/client-s3": "^3.744.0",
     "@prisma/client": "^6.3.1",
     "dotenv": "^16.4.7",
     "openai": "^4.83.0",
     "prisma": "^6.3.1",
     "rimraf": "^6.0.1",
+    "ts-patch": "^3.3.0",
+    "typescript": "~5.8.2",
     "typia": "^8.0.1"
+  },
+  "peerDependencies": {
+    "@agentica/core": "^0.11.1",
+    "openai": "^4.83.0"
   }
 }


### PR DESCRIPTION
This pull request includes changes to the `package.json` file to reorganize dependencies and add peer dependencies. The most important changes include moving `ts-patch` and `typescript` from `devDependencies` to `dependencies`, and adding new `peerDependencies`.

Reorganization of dependencies:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L26-R38): Moved `ts-patch` and `typescript` from `devDependencies` to `dependencies`.

Addition of peer dependencies:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L26-R38): Added `@agentica/core` and `openai` to `peerDependencies`.

The reasons I move libraries to devDependencies are:
- typia: typia is not included in dist
- openai: peerDependencies are better
- agentica: same as openai